### PR TITLE
Increase configuration maximum of keyboard auto repeat rate

### DIFF
--- a/kcms/keyboard/ui/Hardware.qml
+++ b/kcms/keyboard/ui/Hardware.qml
@@ -202,7 +202,7 @@ Kirigami.FormLayout {
             Layout.preferredWidth: Kirigami.Units.gridUnit * 15
 
             from: 20
-            to: 10000
+            to: 20000
             value: kcm.miscSettings.repeatRate * 100
             onMoved: kcm.miscSettings.repeatRate = value / 100
 
@@ -216,7 +216,7 @@ Kirigami.FormLayout {
             Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 
             from: 20
-            to: 10000
+            to: 20000
             stepSize: 500
             value: Math.round(kcm.miscSettings.repeatRate * 100)
             onValueModified: kcm.miscSettings.repeatRate = value / 100


### PR DESCRIPTION
BUG: 488802

The current maximum configurable keyboard auto-repeat rate of 100 is too conservative. Change it to 200.

For me personally, repeat of about 130/s is ideal. Increasing much beyond 130 is too fast for me (too hard to move cursor short distances). I set the maximum to 200 on the assumption that there are people with much faster reflexes than me but 200 "ought to be enough for anybody".